### PR TITLE
Fix DUI slippery flag logic and IllegalArgumentException [1/2]

### DIFF
--- a/src/com/android/systemui/navigation/BaseEditor.java
+++ b/src/com/android/systemui/navigation/BaseEditor.java
@@ -89,9 +89,11 @@ public abstract class BaseEditor implements Editor {
                     final int mode = mMode;
                     if (mode == MODE_ON) {
                         changeEditMode(MODE_OFF);
+                        mHost.setSlippery(true);
                     } else {
                         if (isEditorAvailable()) {
                             changeEditMode(MODE_ON);
+                            mHost.setSlippery(false);
                         } else {
                             toastState(69);
                         }

--- a/src/com/android/systemui/navigation/BaseNavigationBar.java
+++ b/src/com/android/systemui/navigation/BaseNavigationBar.java
@@ -397,7 +397,7 @@ public abstract class BaseNavigationBar extends LinearLayout implements Navigato
         setDisabledFlags(mDisabledFlags, true);
     }
 
-    public void setSlippery(boolean newSlippery) {
+    protected void setSlippery(boolean newSlippery) {
         WindowManager.LayoutParams lp = (WindowManager.LayoutParams) getLayoutParams();
         if (lp != null) {
             boolean oldSlippery = (lp.flags & WindowManager.LayoutParams.FLAG_SLIPPERY) != 0;
@@ -423,7 +423,7 @@ public abstract class BaseNavigationBar extends LinearLayout implements Navigato
 
         if (DEBUG) {
             Log.d(TAG, "reorient(): rot=" + mDisplay.getRotation());
-        }      
+        }
     }
 
     @Override
@@ -447,10 +447,6 @@ public abstract class BaseNavigationBar extends LinearLayout implements Navigato
         final boolean disableBack = ((disabledFlags & View.STATUS_BAR_DISABLE_BACK) != 0)
                 && ((mNavigationIconHints & StatusBarManager.NAVIGATION_HINT_BACK_ALT) == 0);
         final boolean disableSearch = ((disabledFlags & View.STATUS_BAR_DISABLE_SEARCH) != 0);
-
-        if (SLIPPERY_WHEN_DISABLED) {
-            setSlippery(disableHome && disableRecent && disableBack && disableSearch);
-        }
     }
 
     @Override

--- a/src/com/android/systemui/navigation/Navigator.java
+++ b/src/com/android/systemui/navigation/Navigator.java
@@ -58,7 +58,6 @@ public interface Navigator {
     public void setOnVerticalChangedListener(OnVerticalChangedListener onVerticalChangedListener);
     public void dispose();
     public void notifyScreenOn(boolean screenOn);
-    public void setSlippery(boolean newSlippery);
     public void setDisabledFlags(int disabledFlags, boolean force);
     public void setNavigationIconHints(int hints);
     public void setMenuVisibility(boolean showMenu);


### PR DESCRIPTION
On Nougat Google set stock navbar view to always slippery.
We were using the old M logic, setting the slippery flag when needed,
also because of smartbar editor.
But this can give IllegalArgumentException on dpi changes (maybe
a few other situations too) when navbar is redrawing meanwhile
PhoneStatusBar calls BaseNavigationBar.setSlippery, that tries to
updateViewLayout on a non attached (smartbar) view.

With this commit we sync dui LayoutParams with the ones used
by Google on stock navbar view (= we set it to always slippery like
here: https://github.com/android/platform_frameworks_base/commit/c59a23fb1b1ff7c533c220a2464d46ed43f61a1b)
and just disable the slippery flag when smartbar editor is running.

04-16 02:50:59.287  2332  2332 E MessageQueue-JNI: java.lang.IllegalArgumentException: View=com.android.systemui.navigation.smartbar.SmartBarView{415ffb9 V.E...... ......I. 0,0-0,0} not attached to window manager
04-16 02:50:59.287  2332  2332 E MessageQueue-JNI: at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:473)
04-16 02:50:59.287  2332  2332 E MessageQueue-JNI: at android.view.WindowManagerGlobal.updateViewLayout(WindowManagerGlobal.java:368)
04-16 02:50:59.287  2332  2332 E MessageQueue-JNI: at android.view.WindowManagerImpl.updateViewLayout(WindowManagerImpl.java:101)
04-16 02:50:59.287  2332  2332 E MessageQueue-JNI: at com.android.systemui.navigation.BaseNavigationBar.setSlippery(BaseNavigationBar.java:412)
04-16 02:50:59.287  2332  2332 E MessageQueue-JNI: at com.android.systemui.statusbar.phone.PhoneStatusBar.makeExpandedVisible(PhoneStatusBar.java:3617)

04-23 11:30:52.264  6639  6639 D AndroidRuntime: Shutting down VM
04-23 11:30:52.267  6639  6639 E AndroidRuntime: FATAL EXCEPTION: main
04-23 11:30:52.267  6639  6639 E AndroidRuntime: Process: com.android.systemui, PID: 6639
04-23 11:30:52.267  6639  6639 E AndroidRuntime: java.lang.IllegalArgumentException: View=com.android.systemui.navigation.smartbar.SmartBarView{1d1ab35 V.E...... ......I. 0,0-0,0} not attached to window manager
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:473)
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at android.view.WindowManagerGlobal.updateViewLayout(WindowManagerGlobal.java:368)
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at android.view.WindowManagerImpl.updateViewLayout(WindowManagerImpl.java:99)
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at com.android.systemui.navigation.BaseNavigationBar.setSlippery(BaseNavigationBar.java:412)
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at com.android.systemui.statusbar.phone.PhoneStatusBar.makeExpandedVisible(PhoneStatusBar.java:3015)
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at com.android.systemui.statusbar.phone.PhoneStatusBar.instantExpandNotificationsPanel(PhoneStatusBar.java:4854)
04-23 11:30:52.267  6639  6639 E AndroidRuntime:        at com.android.systemui.statusbar.phone.PhoneStatusBar.showKeyguard(PhoneStatusBar.java:4458)

Change-Id: Ice26fc36dac87a632b52b216e32859b8422de8ae